### PR TITLE
[nightshift] docs-backfill: expand README with platform table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebrew-kagi
 
-Homebrew tap for the `kagi` CLI.
+Homebrew tap for the [`kagi`](https://github.com/Microck/kagi-cli) CLI — an agent-native Rust CLI for Kagi subscribers with JSON-first output.
 
 ## Install
 
@@ -15,3 +15,25 @@ brew install kagi
 brew update
 brew upgrade kagi
 ```
+
+## Uninstall
+
+```bash
+brew uninstall kagi
+brew untap Microck/kagi
+```
+
+## Supported Platforms
+
+| OS      | Architecture | Supported |
+|---------|-------------|-----------|
+| macOS   | Apple Silicon (arm64) | ✅ |
+| macOS   | Intel (x86_64) | ✅ |
+| Linux   | ARM64 | ✅ |
+| Linux   | x86_64 | ✅ |
+
+## What is `kagi`?
+
+The `kagi` CLI provides command-line access to Kagi search, summarization, news, translation, and the Kagi Assistant. It is designed for agent workflows with structured JSON output by default.
+
+See the [kagi-cli repository](https://github.com/Microck/kagi-cli) for full documentation.


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** docs-backfill
**Category:** pr
**Changes:** Expanded README with platform table, uninstall instructions, and what-is-kagi section.